### PR TITLE
re.search variables around the wrong way

### DIFF
--- a/riko/modules/filter.py
+++ b/riko/modules/filter.py
@@ -50,7 +50,7 @@ COMBINE_BOOLEAN = {'and': all, 'or': any}
 SWITCH = {
     'contains': lambda x, y: x and y.lower() in x.lower(),
     'doesnotcontain': lambda x, y: x and y.lower() not in x.lower(),
-    'matches': lambda x, y: re.search(x, y),
+    'matches': lambda x, y: re.search(y, x),
     'is': op.eq,
     'isnot': op.ne,
     'truthy': bool,


### PR DESCRIPTION
I found the cause of issue #14 which I logged.

I compared the matches lambda with the contains one and realised that the variables were being passed to re.search backwards. I've tested the change it my example from the issue now works.