### PR TITLE
[CHANGE] set flake8 max-line-length equal to black

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,5 +16,5 @@ always-on=True
 [flake8]
 ignore=W191,E126,E128,E122,E731,F403
 max-complexity=10
-max-line-length=80
+max-line-length=88
 exclude=./build/*,./dist/*,./.tox/*,./riko/lib/.ropeproject/*


### PR DESCRIPTION
This makes it so Kazeeki can use `manage prettify` and the formatters will match in line length requirement.